### PR TITLE
Sandbox: Use the layer's sql if available

### DIFF
--- a/sandbox/scroll.html
+++ b/sandbox/scroll.html
@@ -97,7 +97,11 @@
                       layer_name = layer.layers[0].options.layer_name,
                       filter = actions.global.cartodb_filter ? " WHERE "+actions.global.cartodb_filter : "";
 
-                  sublayer.setSQL("SELECT * FROM "+layer_name+filter)
+                  var sql = layer.layers[0].options.sql;
+                  if (!sql) {
+                      sql = "SELECT * FROM "+layer_name+filter;
+                  }
+                  sublayer.setSQL(sql);
 
                   self.map.addLayer(layer);
 

--- a/sandbox/slides.html
+++ b/sandbox/slides.html
@@ -169,7 +169,11 @@
                       layer_name = layer.layers[0].options.layer_name,
                       filter = actions.global.cartodb_filter ? " WHERE "+actions.global.cartodb_filter : "";
 
-                  sublayer.setSQL("SELECT * FROM "+layer_name+filter)
+                  var sql = layer.layers[0].options.sql;
+                  if (!sql) {
+                      sql = "SELECT * FROM "+layer_name+filter;
+                  }
+                  sublayer.setSQL(sql);
 
                   self.map.addLayer(layer);
 


### PR DESCRIPTION
Partial fix to #205. Attempt to use the layer's sql in its options, if this fails create the sql statement as it was previously.

The current way of creating sql statements often fails because the layer name is used as the table name, but these often do not match (I'm assuming because the CartoDB UI changed to allow customizing layer names).
